### PR TITLE
Run PEP8 on content

### DIFF
--- a/avro_sample.py
+++ b/avro_sample.py
@@ -1,5 +1,7 @@
 # Databricks notebook source
 
+from pyspark.sql.types import *
+from pyspark.sql.functions import *
 dbutils.widgets.text("year", "2019", "Year")
 dbutils.widgets.text("month", "03", "Month")
 dbutils.widgets.text("day", "01", "Day")
@@ -12,8 +14,6 @@ d = dbutils.widgets.get("day")
 
 # COMMAND ----------
 
-from pyspark.sql.functions import *
-from pyspark.sql.types import *
 
 # COMMAND ----------
 
@@ -22,7 +22,8 @@ dbutils.fs.ls("wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows
 # COMMAND ----------
 
 # Path format: partition/year/month/day/hour/minute/
-input_loc = "wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/ehnrtanalytics/ehnrtanalytics-output/*/{}/{}/{}/*/*/".format(y, m, d)
+input_loc = "wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/ehnrtanalytics/ehnrtanalytics-output/*/{}/{}/{}/*/*/".format(
+    y, m, d)
 
 
 # COMMAND ----------
@@ -47,19 +48,23 @@ display(df2)
 
 # COMMAND ----------
 
-df2.write.json('wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/temp_out/', mode="overwrite")
+df2.write.json(
+    'wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/temp_out/', mode="overwrite")
 
 # COMMAND ----------
 
-dbutils.fs.ls("wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/temp_out/")
+dbutils.fs.ls(
+    "wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/temp_out/")
 
 # COMMAND ----------
 
-dfjs = spark.read.json("wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/temp_out/") 
+dfjs = spark.read.json(
+    "wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/temp_out/")
 
 # COMMAND ----------
 
-schema = StructType([StructField("version", StringType()), StructField("userid", StringType()), StructField("platform", StringType())])
+schema = StructType([StructField("version", StringType()), StructField(
+    "userid", StringType()), StructField("platform", StringType())])
 dfx = dfjs.select(from_json("Body", schema).alias("B"))
 
 # COMMAND ----------
@@ -80,9 +85,8 @@ display(dfx2.groupBy("platform").count())
 
 # COMMAND ----------
 
-out_loc = "wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/csv_out/{}/{}/{}".format(year, month, day)
+out_loc = "wasbs://ehcapture-analytics@storagenrtanalytics.blob.core.windows.net/csv_out/{}/{}/{}".format(
+    year, month, day)
 dfx2.write.csv(out_loc, header=True, mode="overwrite")
 
 # COMMAND ----------
-
-


### PR DESCRIPTION
Hello! The Azure documentation team (Content & Learning) is updating existing
Python samples to conform to PEP8. This consists of (only) running `autopep8`
on content. Even if this PR contains only whitespace changes, please accept it.

If you have questions about the rationale behind this change, please email
Microsoft alias `sttramer`.